### PR TITLE
Fixed bug in check shifts

### DIFF
--- a/src/main/java/com/bbn/sd2/MaintainDictionary.java
+++ b/src/main/java/com/bbn/sd2/MaintainDictionary.java
@@ -901,6 +901,10 @@ public final class MaintainDictionary {
                     continue;
                 }
 
+                if(previousRowValue.length() == 0) {
+                        continue;
+                }
+
                 if(previousRowValue.equals(originalValue)) {
                     // The value has shifted up a row
                     Integer count = upShiftCounts.get(key);


### PR DESCRIPTION
In some cases the contents of an empty row are intepreted as an
empty string instead of null.  The check shifts method erroneously
deduced column shifts from empty rows.