### PR TITLE
17 backup tabs

### DIFF
--- a/src/main/java/com/bbn/sd2/DictionaryAccessor.java
+++ b/src/main/java/com/bbn/sd2/DictionaryAccessor.java
@@ -826,7 +826,7 @@ public class DictionaryAccessor {
         requestBody.setDestinationSpreadsheetId(dstSpreadsheetId);
 
         {
-            // Lookup the sheet properties on the destination spreadsheet
+            // Lookup the sheet properties on the source spreadsheet
             Sheets.Spreadsheets.Get get = sheetsService.spreadsheets().get(srcSpreadsheetId).setFields("sheets.properties");
             Spreadsheet s = execute(get);
             List<Sheet> srcSheets = s.getSheets();
@@ -856,10 +856,11 @@ public class DictionaryAccessor {
                 }
 
                 if(srcSheet == null) {
+                    // Tab is not in source spreadsheep
                     continue;
                 }
 
-                // List of requests to send to Google
+                // List of requests to delete tabs
                 List<Request> deleteRequests = new ArrayList<>();
 
                 // Find list of "Copy" destination tabs to delete
@@ -948,9 +949,10 @@ public class DictionaryAccessor {
                 renameRequests.add(req);
             }
 
-            // At this point the tabs should be copied, but their
-            // names begin with "Copy of".  Execute requets to remove
-            // the "Copy of" from the tab names
+            // At this point all tabs should be copied, but their
+            // names begin with "Copy of".  Previous tabs have had
+            // their names prepended with "previous ". Execute requets
+            // to remove the "Copy of" from the tab names
             if(!renameRequests.isEmpty()) {
                 BatchUpdateSpreadsheetRequest breq = new BatchUpdateSpreadsheetRequest();
                 breq.setRequests(renameRequests);

--- a/src/main/java/com/bbn/sd2/MaintainDictionary.java
+++ b/src/main/java/com/bbn/sd2/MaintainDictionary.java
@@ -55,7 +55,7 @@ public final class MaintainDictionary {
     private static final String SD2E_DICTIONARY = STAGING_DICTIONARY;
 
     private static final double googleRequestsPerSecond = 0.5;
-    private static final long msPerGoogleRequest = (long)(1000.0 / googleRequestsPerSecond);
+    public static final long msPerGoogleRequest = (long)(1000.0 / googleRequestsPerSecond);
 
     public static int synBioHubAccessRetryCount = 5;
     public static int synBioHubAccessRetryPauseMS = 1000;


### PR DESCRIPTION
The tab copy method previously did not behave properly if the
destination spreadsheet already had a tab with the same name
as the tab being copied.

Reorded operations a bit to rename old tab in destination
spreadsheet prior to copying, ensuring at least one recent version
of the tab is saved in case the copy operation fails.