### PR TITLE
Fixed empty row bug

### DIFF
--- a/src/main/java/com/bbn/sd2/MaintainDictionary.java
+++ b/src/main/java/com/bbn/sd2/MaintainDictionary.java
@@ -1832,6 +1832,10 @@ public final class MaintainDictionary {
                         rowStr = rowStr.split(":")[0];
                         rowStr = rowStr.substring(1);
 
+                        if(valueRange.getValues() == null) {
+                            continue;
+                        }
+
                         // Create a dictionary entry what is currently
                         // in the spreadsheet
                         int row = (int)Integer.parseInt(rowStr);


### PR DESCRIPTION
An empty row caused an exception in the code that checked for row
updates during processing.  Empty rows are now skipped over.